### PR TITLE
fix: notification typo error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -412,7 +412,7 @@ static int entry_notification_remove(int argc, char **argv)
 
     if (argc < 4)
     {
-        printf("Usage: %s notification retrieve <seqNumber>\n", argv[0]);
+        printf("Usage: %s notification remove <seqNumber>\n", argv[0]);
         return -1;
     }
 


### PR DESCRIPTION
```console
$ ./lpac notification remove
Usage: ./lpac notification retrieve <seqNumber>
$ ./lpac notification retrieve
Unknown command: retrieve
```